### PR TITLE
jsdoc fix

### DIFF
--- a/lib/UHRBase.js
+++ b/lib/UHRBase.js
@@ -99,7 +99,7 @@ function UHRBase() {
  * @param {string} url URL to request.
  * @param {Object?} options Request parameters.
  * @param {Object?} options.headers HTTP headers to send.
- * @param {String|Object?} options.data Data to send.
+ * @param {(String|Object)?} options.data Data to send.
  * @param {Number?} options.timeout Request timeout.
  * @param {Boolean?} options.unsafeHTTPS If true then requests to servers with
  * invalid HTTPS certificates are allowed.
@@ -118,7 +118,7 @@ UHRBase.prototype.get = function (url, options) {
  * @param {string} url URL to request.
  * @param {Object?} options Request parameters.
  * @param {Object?} options.headers HTTP headers to send.
- * @param {String|Object?} options.data Data to send.
+ * @param {(String|Object)?} options.data Data to send.
  * @param {Number?} options.timeout Request timeout.
  * @param {Boolean?} options.unsafeHTTPS If true then requests to servers with
  * invalid HTTPS certificates are allowed.
@@ -137,7 +137,7 @@ UHRBase.prototype.post = function (url, options) {
  * @param {string} url URL to request.
  * @param {Object?} options Request parameters.
  * @param {Object?} options.headers HTTP headers to send.
- * @param {String|Object?} options.data Data to send.
+ * @param {(String|Object)?} options.data Data to send.
  * @param {Number?} options.timeout Request timeout.
  * @param {Boolean?} options.unsafeHTTPS If true then requests to servers with
  * invalid HTTPS certificates are allowed.
@@ -156,7 +156,7 @@ UHRBase.prototype.put = function (url, options) {
  * @param {string} url URL to request.
  * @param {Object?} options Request parameters.
  * @param {Object?} options.headers HTTP headers to send.
- * @param {String|Object?} options.data Data to send.
+ * @param {(String|Object)?} options.data Data to send.
  * @param {Number?} options.timeout Request timeout.
  * @param {Boolean?} options.unsafeHTTPS If true then requests to servers with
  * invalid HTTPS certificates are allowed.
@@ -175,7 +175,7 @@ UHRBase.prototype.patch = function (url, options) {
  * @param {string} url URL to request.
  * @param {Object?} options Request parameters.
  * @param {Object?} options.headers HTTP headers to send.
- * @param {String|Object?} options.data Data to send.
+ * @param {(String|Object)?} options.data Data to send.
  * @param {Number?} options.timeout Request timeout.
  * @param {Boolean?} options.unsafeHTTPS If true then requests to servers with
  * invalid HTTPS certificates are allowed.
@@ -194,7 +194,7 @@ UHRBase.prototype.delete = function (url, options) {
  * @param {String} parameters.method HTTP method.
  * @param {String} parameters.url URL for request.
  * @param {Object?} parameters.headers HTTP headers to send.
- * @param {String|Object?} parameters.data Data to send.
+ * @param {(String|Object)?} parameters.data Data to send.
  * @param {Number?} parameters.timeout Request timeout.
  * @param {Boolean?} parameters.unsafeHTTPS If true then requests
  * to servers with invalid HTTPS certificates are allowed.
@@ -214,7 +214,7 @@ UHRBase.prototype.request = function (parameters) {
  * @param {String} parameters.method HTTP method.
  * @param {String} parameters.url URL for request.
  * @param {Object?} parameters.headers HTTP headers to send.
- * @param {String|Object?} parameters.data Data to send.
+ * @param {(String|Object)?} parameters.data Data to send.
  * @param {Number?} parameters.timeout Request timeout.
  * @param {Boolean?} parameters.unsafeHTTPS If true then requests
  * to servers with invalid HTTPS certificates are allowed.


### PR DESCRIPTION
We've faced an issue while generating jsdoc documentation from these sources, see https://github.com/ForNeVeR/catberry-ts/issues/27 for details. The problem can be demonstrated with parameter type declared as `String|Object?`. I haven't found any corresponding example in the [jsdoc documentation](http://usejsdoc.org/tags-param.html) but from my experiments it seems that it will be proper to take types in parentheses: `(String|Object)?`.